### PR TITLE
Update cabal dependency version bounds

### DIFF
--- a/postie.cabal
+++ b/postie.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name: postie
-version: 0.6.0.2
+version: 0.6.0.3
 build-type: Simple
 license: BSD3
 license-file: LICENSE
@@ -47,15 +47,15 @@ flag examples
 
 library
   build-depends:
-    attoparsec           >= 0.13.2 && < 0.14,
-    base                 >= 4.13.0 && < 4.14,
-    bytestring           >= 0.10.10 && < 0.11,
+    attoparsec           >= 0.13.2.3 && < 0.15,
+    base                 >= 4.13.0 && < 4.16,
+    bytestring           >= 0.10.10 && < 0.12,
     data-default-class   >= 0.1.2 && < 0.2,
-    mtl                  >= 2.2.2 && < 2.3,
+    mtl                  >= 2.2.2 && < 2.4,
     network              >= 3.1.1 && < 3.2,
     pipes                >= 4.3.14 && < 4.4,
     pipes-parse          >= 3.0.8 && < 3.1,
-    tls                  >= 1.5.4 && < 1.6,
+    tls                  >= 1.5.4 && < 1.7,
     uuid                 >= 1.3.13 && < 1.4
   exposed-modules: 
     Network.Mail.Postie
@@ -85,7 +85,7 @@ library
 executable postie-example-simple
   build-depends:
     postie,
-    base                 >= 4.13.0 && < 4.14,
+    base                 >= 4.13.0 && < 4.16,
     pipes-bytestring     >= 2.1.6 && < 2.2
   if flag(examples)
     buildable: True
@@ -99,7 +99,7 @@ executable postie-example-simple
 executable postie-example-tls
   build-depends:
     postie,
-    base                 >= 4.13.0 && < 4.14,
+    base                 >= 4.13.0 && < 4.16,
     pipes-bytestring     >= 2.1.6 && < 2.2
   if flag(examples)
     buildable: True

--- a/src/Network/Mail/Postie/Connection.hs
+++ b/src/Network/Mail/Postie/Connection.hs
@@ -75,7 +75,7 @@ connClose (Connection cbe) = closeBackend =<< readIORef cbe
     closeBackend (ConnPlain s) = close s
     closeBackend (ConnSecure context) = bye context `finally` contextClose context
 
-toProducer :: (MonadIO m) => Connection -> P.Producer' BS.ByteString m ()
+toProducer :: (MonadIO m) => Connection -> P.Producer BS.ByteString m ()
 toProducer conn = go
   where
     go = do


### PR DESCRIPTION
The cabal file's lower version bounds were tested with GHC 8.8.4. The upper bounds with 9.0.2.

Especially, the increase of the `base` upper bound is interesting, as it allows to use this package with current versions of GHC.