### PR TITLE
bump bytestring upper bound to allow ghc 9.8

### DIFF
--- a/postie.cabal
+++ b/postie.cabal
@@ -49,7 +49,7 @@ library
   build-depends:
     attoparsec           >= 0.13.2.3 && < 0.15,
     base ,
-    bytestring           >= 0.10.10 && < 0.12,
+    bytestring           >= 0.10.10 && < 0.13,
     data-default-class   >= 0.1.2 && < 0.2,
     mtl                  >= 2.2.2 && < 2.4,
     network              >= 3.1.1 && < 3.2,


### PR DESCRIPTION
This bumps the `bytestring` dependency to allow for compilation with GHC version 9.8. 