### PR TITLE
fix: Use data-default package instead of data-default-class

### DIFF
--- a/postie.cabal
+++ b/postie.cabal
@@ -48,9 +48,9 @@ flag examples
 library
   build-depends:
     attoparsec           >= 0.13.2.3 && < 0.15,
-    base ,
+    base                 >= 4.13.0 && < 5,
     bytestring           >= 0.10.10 && < 0.13,
-    data-default-class   >= 0.1.2 && < 0.2,
+    data-default         >= 0.8 && <0.9,
     mtl                  >= 2.2.2 && < 2.4,
     network              >= 3.1.1 && < 3.2,
     pipes                >= 4.3.14 && < 4.4,
@@ -85,7 +85,7 @@ library
 executable postie-example-simple
   build-depends:
     postie,
-    base,
+    base                 >= 4.13.0 && < 5,
     pipes-bytestring     >= 2.1.6 && < 2.2
   if flag(examples)
     buildable: True
@@ -99,7 +99,7 @@ executable postie-example-simple
 executable postie-example-tls
   build-depends:
     postie,
-    base,
+    base                 >= 4.13.0 && < 5,
     pipes-bytestring     >= 2.1.6 && < 2.2
   if flag(examples)
     buildable: True

--- a/src/Network/Mail/Postie/Settings.hs
+++ b/src/Network/Mail/Postie/Settings.hs
@@ -13,7 +13,7 @@ where
 import Control.Applicative
 import Control.Exception
 import Data.ByteString (ByteString)
-import Data.Default.Class
+import Data.Default
 import GHC.IO.Exception (IOErrorType (..))
 import Network.Socket (HostName, PortNumber, SockAddr)
 import qualified Network.TLS as TLS


### PR DESCRIPTION
[tls-2.1.2](https://hackage.haskell.org/package/tls-2.1.2) migrated to use the `data-default` package instead of `data-default-class`, so master doesn't build against latest Hackage because the Default class that the TLS settings implement and the Default instances that the `tls` package provides are technically different typeclasses.

Also put back some reasonable bounds on base that were removed in https://github.com/alexbiehl/postie/pull/4, while still allowing newer versions of GHC.