### PR TITLE
fix: Make sure additional HELO/EHLO are spec compliant

### DIFF
--- a/src/Network/Mail/Postie/Protocol.hs
+++ b/src/Network/Mail/Postie/Protocol.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS -fmax-pmcheck-models=100 #-}
+
 module Network.Mail.Postie.Protocol
   ( TlsStatus (..),
     AuthStatus (..),
@@ -88,9 +90,9 @@ handleSmtpCmd st cmd tlsSt auth = match tlsSt auth st cmd
     match _ _ HaveData Data = undefined
     match _ _ _ Quit = trans (HaveQuit, WantQuit)
     match _ _ Unknown (Helo x) = trans (HaveHelo, SayHelo x)
-    match _ _ _ (Helo x) = event (SayHeloAgain x)
+    match _ _ _ (Helo x) = trans (HaveHelo, SayHeloAgain x)
     match _ _ Unknown (Ehlo x) = trans (HaveEhlo, SayEhlo x)
-    match _ _ _ (Ehlo x) = event (SayEhloAgain x)
+    match _ _ _ (Ehlo x) = trans (HaveEhlo, SayEhloAgain x)
     match Required _ _ (MailFrom _) = event NeedStartTlsFirst
     match _ AuthRequired _ (MailFrom _) = event NeedAuthFirst
     match _ _ Unknown (MailFrom _) = event NeedHeloFirst

--- a/src/Network/Mail/Postie/Session.hs
+++ b/src/Network/Mail/Postie/Session.hs
@@ -122,8 +122,12 @@ handleEvent (SayEhlo x) = do
   result <- handleHelo x
   handlerResponse result $
     sendReply =<< ehloAdvertisement
-handleEvent (SayEhloAgain _) = sendReply ok
-handleEvent (SayHeloAgain _) = sendReply ok
+handleEvent (SayEhloAgain _) = do
+  sendReply ok
+  modify (\ss -> ss {sessionTransaction = TxnInitial})
+handleEvent (SayHeloAgain _) = do
+  sendReply ok
+  modify (\ss -> ss {sessionTransaction = TxnInitial})
 handleEvent SayOK = sendReply ok
 handleEvent (SetMailFrom x) = do
   SessionEnv


### PR DESCRIPTION
Hello again!

I'm back again, this time with a small feature enhancement/fix. From [RFC 5321 §4.1.4](https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.4), additional HELO/EHLO commands sent after the first should act the same as an RSET (so clear the from/recipient buffers). Right now postie is leaving the session state exactly the same.

Mostly a small edge case, but doesn't hurt to be closer to spec-compliant.