### PR TITLE
fix: Various bug/crash fixes with MAIL/RCPT/DATA sequencing

### DIFF
--- a/src/Network/Mail/Postie/Protocol.hs
+++ b/src/Network/Mail/Postie/Protocol.hs
@@ -38,7 +38,6 @@ data SessionState
   | HaveEhlo
   | HaveMailFrom
   | HaveRcptTo
-  | HaveData
   | HaveQuit
 
 type Mailbox = Address
@@ -63,6 +62,7 @@ data Event
   | NeedHeloFirst
   | NeedMailFromFirst
   | NeedRcptToFirst
+  | AlreadyInMailTxn
   deriving (Eq, Show)
 
 data Command
@@ -88,7 +88,6 @@ handleSmtpCmd st cmd tlsSt auth = match tlsSt auth st cmd
   where
     match :: TlsStatus -> AuthStatus -> SessionState -> Command -> (Event, SmtpFSM)
     match _ _ HaveQuit _ = error "received command after QUIT"
-    match _ _ HaveData Data = trans (HaveEhlo, NeedMailFromFirst)
     match _ _ _ Quit = trans (HaveQuit, WantQuit)
     match _ _ Unknown (Helo x) = trans (HaveHelo, SayHelo x)
     match _ _ _ (Helo x) = trans (HaveHelo, SayHeloAgain x)
@@ -97,20 +96,22 @@ handleSmtpCmd st cmd tlsSt auth = match tlsSt auth st cmd
     match Required _ _ (MailFrom _) = event NeedStartTlsFirst
     match _ AuthRequired _ (MailFrom _) = event NeedAuthFirst
     match _ _ Unknown (MailFrom _) = event NeedHeloFirst
-    match _ _ _ (MailFrom x) = trans (HaveMailFrom, SetMailFrom x)
+    match _ _ HaveHelo (MailFrom x) = trans (HaveMailFrom, SetMailFrom x)
+    match _ _ HaveEhlo (MailFrom x) = trans (HaveMailFrom, SetMailFrom x)
+    match _ _ _ (MailFrom _) = event AlreadyInMailTxn
     match Required _ _ (RcptTo _) = event NeedStartTlsFirst
     match _ AuthRequired _ (RcptTo _) = event NeedAuthFirst
     match _ _ Unknown (RcptTo _) = event NeedHeloFirst
-    match _ _ HaveHelo (RcptTo _) = event NeedMailFromFirst
-    match _ _ HaveEhlo (RcptTo _) = event NeedMailFromFirst
-    match _ _ _ (RcptTo x) = trans (HaveRcptTo, AddRcptTo x)
+    match _ _ HaveMailFrom (RcptTo x) = trans (HaveRcptTo, AddRcptTo x)
+    match _ _ HaveRcptTo (RcptTo x) = event (AddRcptTo x)
+    match _ _ _ (RcptTo _) = event NeedMailFromFirst
     match Required _ _ Data = event NeedStartTlsFirst
     match _ AuthRequired _ Data = event NeedAuthFirst
     match _ _ Unknown Data = event NeedHeloFirst
     match _ _ HaveHelo Data = event NeedMailFromFirst
     match _ _ HaveEhlo Data = event NeedMailFromFirst
     match _ _ HaveMailFrom Data = event NeedRcptToFirst
-    match _ _ HaveRcptTo Data = trans (HaveData, StartData)
+    match _ _ HaveRcptTo Data = trans (HaveEhlo, StartData)
     match Required _ _ Rset = event NeedStartTlsFirst
     match _ _ _ Rset = trans (HaveHelo, WantReset)
     match Active _ _ StartTls = event TlsAlreadyActive

--- a/src/Network/Mail/Postie/Protocol.hs
+++ b/src/Network/Mail/Postie/Protocol.hs
@@ -87,8 +87,8 @@ handleSmtpCmd :: SessionState -> Command -> TlsStatus -> AuthStatus -> (Event, S
 handleSmtpCmd st cmd tlsSt auth = match tlsSt auth st cmd
   where
     match :: TlsStatus -> AuthStatus -> SessionState -> Command -> (Event, SmtpFSM)
-    match _ _ HaveQuit _ = undefined
-    match _ _ HaveData Data = undefined
+    match _ _ HaveQuit _ = error "received command after QUIT"
+    match _ _ HaveData Data = trans (HaveHelo, NeedMailFromFirst)
     match _ _ _ Quit = trans (HaveQuit, WantQuit)
     match _ _ Unknown (Helo x) = trans (HaveHelo, SayHelo x)
     match _ _ _ (Helo x) = trans (HaveHelo, SayHeloAgain x)

--- a/src/Network/Mail/Postie/Protocol.hs
+++ b/src/Network/Mail/Postie/Protocol.hs
@@ -88,7 +88,7 @@ handleSmtpCmd st cmd tlsSt auth = match tlsSt auth st cmd
   where
     match :: TlsStatus -> AuthStatus -> SessionState -> Command -> (Event, SmtpFSM)
     match _ _ HaveQuit _ = error "received command after QUIT"
-    match _ _ HaveData Data = trans (HaveHelo, NeedMailFromFirst)
+    match _ _ HaveData Data = trans (HaveEhlo, NeedMailFromFirst)
     match _ _ _ Quit = trans (HaveQuit, WantQuit)
     match _ _ Unknown (Helo x) = trans (HaveHelo, SayHelo x)
     match _ _ _ (Helo x) = trans (HaveHelo, SayHeloAgain x)

--- a/src/Network/Mail/Postie/Session.hs
+++ b/src/Network/Mail/Postie/Session.hs
@@ -209,6 +209,8 @@ handleEvent NeedMailFromFirst =
   sendReply $ reply 503 "Need MAIL FROM first"
 handleEvent NeedRcptToFirst =
   sendReply $ reply 503 "Need RCPT TO first"
+handleEvent AlreadyInMailTxn =
+  sendReply $ reply 503 "Already in mail transaction"
 handleEvent _ = error "impossible"
 
 handlerResponse :: HandlerResponse -> SessionM () -> SessionM ()


### PR DESCRIPTION
1. Sending a `DATA` after a `DATA` would crash the connection with `undefined`, because of an explicit undefined on the (HaveData, Data) pair. The HaveData state seems unnecessary to me, since nothing keys off of it, and after the session loop finishes reading the email body, we should effectively be in the same state as after a `HELO`/`EHLO`.
2. Sending a `RCPT` after a `DATA` would crash, partly because of that HaveData state. The transition to HaveRcptTo didn't care about what its prior state was, so the session loop would attempt to add a transaction recipient despite being in TxnInitial.
3. `MAIL` could erroneously be sent multiple times in sequence, or even after seeing a `RCPT`, causing the state machine to transition "backwards" and forget recipients. As per https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.4,

        MAIL (or SEND, SOML, or SAML) MUST NOT be
        sent if a mail transaction is already open, i.e., it should be sent
        only if no mail transaction had been started in the session, or if
        the previous one successfully concluded with a successful DATA
        command, or if the previous one was aborted, e.g., with a RSET or new
        EHLO.