### PR TITLE
security: Use default TLS versions from tls package

### DIFF
--- a/src/Network/Mail/Postie/Settings.hs
+++ b/src/Network/Mail/Postie/Settings.hs
@@ -123,7 +123,7 @@ defaultTLSSettings =
       keyFile = "key.pem",
       security = DemandStartTLS,
       tlsLogging = def,
-      tlsAllowedVersions = [TLS.SSL3, TLS.TLS10, TLS.TLS11, TLS.TLS12],
+      tlsAllowedVersions = TLS.supportedVersions TLS.defaultSupported,
       tlsCiphers = TLS.ciphersuite_default
     }
 


### PR DESCRIPTION
Rather than hardcoding a list of default TLS versions, it seems more prudent to follow whatever the defaults are in the `tls` package that we've linked against.

This also fixes a security issue; `tls` takes this list of versions in *priority order*, which means postie would have been preferentially picking insecure TLS versions. On latest `tls`, the default supported versions are `[TLS.TLS13, TLS.TLS12]`, in that order.