### PR TITLE
ci: Add Github Actions CI, building through Nix

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -10,5 +10,5 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
+          nix_path: nixpkgs=channel:nixpkgs-unstable
       - run: nix-build ./.

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,0 +1,14 @@
+name: ci-build
+run-name: ${{ github.actor }}-ci-build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-25.05
+      - run: nix-build ./.

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,3 @@
 { pkgs ? import <nixpkgs> {} }:
-pkgs.haskellPackages.callCabal2nix "postie" ./. {}
+pkgs.haskell.lib.compose.doJailbreak
+  (pkgs.haskellPackages.callCabal2nix "postie" ./. {})

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,2 @@
 { pkgs ? import <nixpkgs> {} }:
-pkgs.haskell.lib.compose.doJailbreak
-  (pkgs.haskellPackages.callCabal2nix "postie" ./. {})
+pkgs.haskellPackages.callCabal2nix "postie" ./. {}

--- a/postie.cabal
+++ b/postie.cabal
@@ -52,7 +52,7 @@ library
     bytestring           >= 0.10.10 && < 0.13,
     data-default         >= 0.8 && <0.9,
     mtl                  >= 2.2.2 && < 2.4,
-    network              >= 3.1.1 && < 3.2,
+    network              >= 3.1.1 && < 3.3,
     pipes                >= 4.3.14 && < 4.4,
     pipes-parse          >= 3.0.8 && < 3.1,
     tls                  >= 1.9,


### PR DESCRIPTION
GH Actions for public repos is free! As per https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories

> For public repositories, jobs using the workflow labels shown in the table below will run with the associated specifications. With the exception of single-CPU runners, each GitHub-hosted runner is a new virtual machine (VM) hosted by GitHub. Single-CPU runners are hosted in a container on a shared VM—see [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners). **Use of the standard GitHub-hosted runners is free and unlimited on public repositories.**

and https://docs.github.com/en/billing/concepts/product-billing/github-actions#free-use-of-github-actions:

> The use of standard GitHub-hosted runners is free:
> 
>   * In public repositories
>   * For GitHub Pages
>   * For Dependabot
>   * For the agentic features (public preview) in GitHub Copilot code review

Also bumps the upper bound on the `network` package for `network-3.2.8.0`.